### PR TITLE
Bound in-memory event queue to prevent unbounded growth during Splunk outages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.venv/
+venv/

--- a/hass_splunk/__init__.py
+++ b/hass_splunk/__init__.py
@@ -1,11 +1,20 @@
 import asyncio
 import json
+import logging
 from collections import deque
 from typing import Any, Deque, Dict, Optional, Union
 
 import aiohttp
 
+_LOGGER = logging.getLogger(__name__)
+
 SPLUNK_PAYLOAD_LIMIT = 512000  # 500KB, Actual limit is 512KB/880MB depending on version.
+
+# Bound the in-memory event queue so a Splunk outage or backpressure cannot grow
+# it without limit. With drop-oldest semantics this caps worst-case memory: Home
+# Assistant events are typically a few hundred bytes to ~1KB of JSON, so the
+# default keeps the buffer to a few MB even when Splunk is unreachable.
+DEFAULT_MAX_QUEUE = 8192
 
 
 class SplunkPayloadError(aiohttp.ClientPayloadError):
@@ -29,19 +38,56 @@ class hass_splunk:
         verify_ssl: bool = True,
         endpoint: str = "collector/event",
         timeout: Union[int, float] = 60,
+        max_queue: int = DEFAULT_MAX_QUEUE,
     ) -> None:
         self.session = session
         self.url = f"{['http', 'https'][use_ssl]}://{host}:{port}/services/{endpoint}"
         self.verify_ssl = verify_ssl
         self.headers = {"Authorization": f"Splunk {token}"}
         self.timeout = aiohttp.ClientTimeout(total=timeout)
-        self.batch: Deque[str] = deque()
+        self.max_queue = max_queue
+        # Bounded, drop-oldest buffer: appending to a full deque discards the
+        # oldest event so a Splunk outage cannot grow memory without limit.
+        self.batch: Deque[str] = deque(maxlen=max_queue)
         self.lock = asyncio.Lock()
+        # Tracks whether we are currently in a "dropping events" episode so the
+        # warning is emitted once per episode rather than once per dropped event.
+        self._dropping = False
+
+    def _note_dropped(self, count: int) -> None:
+        """Warn once per drop episode when the bounded queue discards events."""
+        if count <= 0:
+            return
+        if not self._dropping:
+            self._dropping = True
+            _LOGGER.warning(
+                "Splunk event queue full (max_queue=%d); dropping oldest events. "
+                "Splunk is likely unreachable or too slow to keep up.",
+                self.max_queue,
+            )
+
+    def _requeue(self, events: Deque[str]) -> None:
+        """Put un-sent events back at the front of the bounded queue.
+
+        Rebuilds the deque with the original ``maxlen`` so the cap and
+        drop-oldest semantics survive the requeue. Re-queued events go back to
+        the front (oldest first); if the combined length exceeds the cap the
+        oldest events are dropped.
+        """
+        combined = list(events)
+        combined.extend(self.batch)
+        overflow = len(combined) - self.max_queue if self.max_queue else 0
+        self.batch = deque(combined, maxlen=self.max_queue)
+        self._note_dropped(overflow)
 
     async def queue(self, payload: Any, send: bool = True) -> Optional[bool]:
         if not isinstance(payload, str):
             payload = json.dumps(payload)
 
+        # A full bounded deque drops its oldest event on append; detect that so
+        # the drop is logged rather than silently losing data.
+        if self.max_queue and len(self.batch) >= self.max_queue:
+            self._note_dropped(1)
         self.batch.append(payload)
         if send:
             return await self.send()
@@ -92,7 +138,7 @@ class hass_splunk:
                             resp.raise_for_status()
                         if typed_reply["code"] != 0:
                             if resp.status in [500, 503]:  # Only retry on server errors
-                                self.batch = events + self.batch
+                                self._requeue(events)
                             raise SplunkPayloadError(
                                 code=int(typed_reply["code"]),
                                 message=str(typed_reply["text"]),
@@ -105,9 +151,11 @@ class hass_splunk:
                     asyncio.TimeoutError,
                 ) as error:
                     # Requeue failed events before raising the error
-                    self.batch = events + self.batch
+                    self._requeue(events)
                     raise error
 
+        # The queue drained fully; a new outage starts a fresh drop episode.
+        self._dropping = False
         return True
 
     async def check(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hass_splunk",
-    version="0.1.4",
+    version="0.2.0",
     author="Brett Adams",
     author_email="brett@ba.id.au",
     description="Async single threaded connector to Splunk HEC using an asyncio session",

--- a/tests/test_queue_bound.py
+++ b/tests/test_queue_bound.py
@@ -1,0 +1,127 @@
+"""Tests for the bounded, drop-oldest event queue in hass_splunk.
+
+No third-party test runner is required beyond ``aiohttp`` (which the library
+already depends on). Run directly with::
+
+    python -m unittest tests.test_queue_bound
+
+or via pytest if available.
+"""
+
+import asyncio
+import unittest
+from collections import deque
+from contextlib import asynccontextmanager
+from typing import List
+
+from hass_splunk import DEFAULT_MAX_QUEUE, hass_splunk
+
+
+class _FakeResponse:
+    """Minimal stand-in for an aiohttp response with a fixed JSON body."""
+
+    def __init__(self, status: int, body: dict) -> None:
+        self.status = status
+        self._body = body
+        self.request_info = None
+        self.history = ()
+        self.headers = {}
+
+    async def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeSession:
+    """Records POST bodies and replies with a scripted status/JSON code."""
+
+    def __init__(self, status: int, code: int) -> None:
+        self.status = status
+        self.code = code
+        self.sent_bodies: List[str] = []
+
+    @asynccontextmanager
+    async def post(self, url, data=None, **kwargs):
+        if data is not None:
+            self.sent_bodies.append(data)
+        yield _FakeResponse(self.status, {"code": self.code, "text": "scripted"})
+
+
+def _client(session, max_queue: int) -> hass_splunk:
+    return hass_splunk(session, token="t", host="h", max_queue=max_queue)
+
+
+class QueueBoundTests(unittest.TestCase):
+    def test_default_cap_applied(self):
+        client = _client(_FakeSession(200, 0), DEFAULT_MAX_QUEUE)
+        self.assertEqual(client.batch.maxlen, DEFAULT_MAX_QUEUE)
+
+    def test_queue_never_exceeds_cap(self):
+        async def run():
+            client = _client(_FakeSession(200, 0), max_queue=10)
+            for i in range(1000):
+                await client.queue(f"event-{i}", send=False)
+            return client
+
+        client = asyncio.run(run())
+        self.assertEqual(len(client.batch), 10)
+        self.assertLessEqual(len(client.batch), client.max_queue)
+        # Drop-oldest: only the newest 10 events survive, in order.
+        self.assertEqual(
+            list(client.batch),
+            [f"event-{i}" for i in range(990, 1000)],
+        )
+
+    def test_requeue_preserves_order_and_bound(self):
+        client = _client(_FakeSession(200, 0), max_queue=5)
+        # Newer events already waiting in the queue.
+        client.batch = deque(["c", "d", "e"], maxlen=5)
+        # Older, un-sent events come back to the front.
+        client._requeue(deque(["a", "b"]))
+        self.assertEqual(list(client.batch), ["a", "b", "c", "d", "e"])
+        self.assertEqual(client.batch.maxlen, 5)
+
+    def test_requeue_drops_oldest_when_over_cap(self):
+        client = _client(_FakeSession(200, 0), max_queue=4)
+        client.batch = deque(["c", "d", "e"], maxlen=4)
+        # Requeuing 3 older events would make 6 > cap of 4; oldest dropped first.
+        client._requeue(deque(["a1", "a2", "a3"]))
+        self.assertEqual(len(client.batch), 4)
+        # Oldest ("a1", "a2") dropped, front-most retained event is "a3".
+        self.assertEqual(list(client.batch), ["a3", "c", "d", "e"])
+        self.assertTrue(client._dropping)
+
+    def test_server_error_requeues_within_cap(self):
+        async def run():
+            # code 8 (server error) + HTTP 503 -> events get requeued.
+            session = _FakeSession(503, 8)
+            client = _client(session, max_queue=3)
+            for i in range(3):
+                await client.queue(f"e{i}", send=False)
+            with self.assertRaises(Exception):
+                await client.send()
+            return client
+
+        client = asyncio.run(run())
+        # Requeue must not exceed the cap even after a failed send.
+        self.assertLessEqual(len(client.batch), client.max_queue)
+        self.assertEqual(client.batch.maxlen, 3)
+
+    def test_successful_drain_resets_drop_episode(self):
+        async def run():
+            session = _FakeSession(200, 0)  # success
+            client = _client(session, max_queue=3)
+            client._dropping = True  # pretend a prior outage dropped events
+            await client.queue("x", send=False)
+            await client.send()
+            return client
+
+        client = asyncio.run(run())
+        self.assertFalse(client._dropping)
+        self.assertEqual(len(client.batch), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`self.batch` was an unbounded `deque()`. Every `queue()` call appends an event, and on a Splunk server error (500/503) or a connection/timeout failure the un-sent events are re-prepended to the buffer (`self.batch = events + self.batch`) — but nothing ever drops them. With Splunk unreachable or slow on a high-event-rate Home Assistant instance, `self.batch` grows monotonically until recovery or restart. This is a memory-leak risk (the library is the `hass-splunk` PyPI dependency of HA's Splunk integration).

## Fix

- **Bounded, drop-oldest buffer.** New optional, keyword-compatible constructor parameter `max_queue: int = 8192` (added at the end of the signature — existing callers are unaffected). The buffer is now `deque(maxlen=max_queue)`, so appends past the cap discard the **oldest** event.
- **Bound preserved on the requeue path.** `self.batch = events + self.batch` produced a plain deque and silently lost `maxlen`. Both requeue sites now call a new `_requeue()` helper that rebuilds the deque with the original `maxlen`. Re-queued (older) events go back to the **front**; when the combined length exceeds the cap the oldest are dropped first — ordering and the bound both hold.
- **Rate-limited warning on drops.** A module `_LOGGER` emits a `warning` **once per drop episode** (tracked by `self._dropping`, reset when the queue fully drains) rather than once per dropped event.

## Chosen default cap — why 8192

Home Assistant state events serialize to roughly a few hundred bytes to ~1 KB of JSON each. A cap of 8192 events bounds worst-case memory to a few MB (~2–8 MB depending on event size) while being generous enough that a normal instance never trims the buffer during a brief outage. Callers that need more or less headroom can tune `max_queue`. No dynamic/byte-accounting complexity — a simple element cap is sufficient.

## Validation

No test suite or lint/type config existed in the repo (CI is publish-on-release only). Added `tests/test_queue_bound.py` (uses only `unittest` + the existing `aiohttp` dependency, with a fake session/response) proving: the cap holds under 1000 appends, drop-oldest ordering, requeue preserves order + bound, requeue drops oldest when over cap, the server-error (503/code 8) requeue path stays within the cap, and the drop episode resets on a successful drain.

```
=== mypy (hass_splunk/__init__.py) ===
Success: no issues found in 1 source file

=== python -m unittest tests.test_queue_bound ===
......
----------------------------------------------------------------------
Ran 6 tests in 0.001s

OK
```

(`mypy` run in a throwaway venv since no type-check tooling ships with the repo; the package carries `py.typed` and stays type-clean. Also added a minimal `.gitignore` for `__pycache__`/build artifacts.)

## Release

- Version bumped `0.1.4 → 0.2.0` in `setup.py` (new feature → minor bump) so a release can be cut.
- **Follow-ups for the captain/firstmate after merge:** publishing to PyPI (the release-triggered workflow) and the corresponding `manifest.json` requirement bump in `home-assistant/core` are separate steps, not included here.
